### PR TITLE
更新 README 与 Docker 镜像为 truewhile 仓库

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ MMTL 是自托管媒体系统，常部署在 NAS、家庭网络、Docker、反�
 我们优先支持以下版本和部署方式的安全修复：
 
 - 当前 `main` 分支。
-- 最新发布镜像：`ghcr.io/shukebta/mmtl:latest`。
+- 最新发布镜像：`ghcr.io/truewhile/mmtl:latest`。
 - README 中推荐的 Docker Compose 第一档、第二档、第三档部署方式。
 
 历史版本、私有魔改镜像、未公开补丁分支和非标准部署仍可报告，但维护者可能要求先在最新 `main` 或最新镜像中复现。

--- a/docker-compose.search.yml
+++ b/docker-compose.search.yml
@@ -20,11 +20,7 @@
 
 services:
   mmtl:
-    # 镜像二选一：
-    # 方式一：GitHub 仓库镜像 GHCR（默认，推荐）
-    image: ghcr.io/shukebta/mmtl:latest
-    # 方式二：Docker Hub 备用（GHCR 拉取慢或不可用时使用）
-    # image: shukbet/mmtl:latest
+    image: ghcr.io/truewhile/mmtl:latest
 
     restart: unless-stopped
     init: true
@@ -101,7 +97,7 @@ services:
       MMTL_SEARCH_OPENSEARCH_URL: http://opensearch:9200
       MMTL_SEARCH_INDEX: mmtl_media
 
-      MMTL_UPDATE_IMAGE: ghcr.io/shukebta/mmtl:latest
+      MMTL_UPDATE_IMAGE: ghcr.io/truewhile/mmtl:latest
 
       # 默认推荐在网页里使用容器路径 /media。
       # 如果旧媒体库已经保存了宿主机路径 /vol1/1000/Media，

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -13,9 +13,7 @@
 
 services:
   mmtl:
-    image: ghcr.io/shukebta/mmtl:latest
-    # Docker Hub 备用：
-    # image: shukbet/mmtl:latest
+    image: ghcr.io/truewhile/mmtl:latest
 
     container_name: mmtl
     restart: unless-stopped

--- a/docker-compose.standard.yml
+++ b/docker-compose.standard.yml
@@ -17,11 +17,7 @@
 
 services:
   mmtl:
-    # 镜像二选一：
-    # 方式一：GitHub 仓库镜像 GHCR（默认，推荐）
-    image: ghcr.io/shukebta/mmtl:latest
-    # 方式二：Docker Hub 备用（GHCR 拉取慢或不可用时使用）
-    # image: shukbet/mmtl:latest
+    image: ghcr.io/truewhile/mmtl:latest
 
     restart: unless-stopped
     init: true
@@ -92,7 +88,7 @@ services:
       MMTL_CACHE_REDIS_URL: redis://redis:6379/0
       MMTL_CACHE_CACHE_DIR: /cache
 
-      MMTL_UPDATE_IMAGE: ghcr.io/shukebta/mmtl:latest
+      MMTL_UPDATE_IMAGE: ghcr.io/truewhile/mmtl:latest
 
       # 路径换算配置。左边宿主机真实路径要和 volumes 左边保持一致。
       MMTL_MEDIA_DIR: /media

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,7 @@
 
 services:
   mmtl:
-    # 镜像二选一：
-    # 方式一：GitHub 仓库镜像 GHCR（默认，推荐）
-    image: ghcr.io/shukebta/mmtl:latest
-    # 方式二：Docker Hub 备用（GHCR 拉取慢或不可用时使用）
-    # image: shukbet/mmtl:latest
+    image: ghcr.io/truewhile/mmtl:latest
 
     restart: unless-stopped
     init: true
@@ -112,7 +108,7 @@ services:
       MMTL_CACHE_CACHE_DIR: /cache
 
       # 管理面板热更新默认拉取此镜像，并用 Watchtower 一次性重建当前容器。
-      MMTL_UPDATE_IMAGE: ghcr.io/shukebta/mmtl:latest
+      MMTL_UPDATE_IMAGE: ghcr.io/truewhile/mmtl:latest
 
       # 路径换算配置。
       # 默认推荐在网页里使用容器路径 /media。

--- a/internal/service/system_update.go
+++ b/internal/service/system_update.go
@@ -20,7 +20,7 @@ const (
 	SystemUpdateCommandSettingKey         = "system.update.command"
 	SystemUpdateComposeDirSettingKey      = "system.update.compose_dir"
 
-	DefaultSystemUpdateImage           = "ghcr.io/shukebta/mmtl:latest"
+	DefaultSystemUpdateImage           = "ghcr.io/truewhile/mmtl:latest"
 	DefaultSystemUpdateWatchtowerImage = "containrrr/watchtower:latest"
 )
 

--- a/internal/service/system_update_test.go
+++ b/internal/service/system_update_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRenderSystemUpdateCommand(t *testing.T) {
 	status := SystemUpdateStatus{
-		Image:           "ghcr.io/shukebta/mmtl:latest",
+		Image:           "ghcr.io/truewhile/mmtl:latest",
 		WatchtowerImage: "containrrr/watchtower:latest",
 		ContainerID:     "abc123def456",
 		ContainerName:   "mmtl",
@@ -28,7 +28,7 @@ func TestRenderSystemUpdateCommand(t *testing.T) {
 	for _, want := range []string{
 		"containrrr/watchtower:latest",
 		"mmtl",
-		"ghcr.io/shukebta/mmtl:latest",
+		"ghcr.io/truewhile/mmtl:latest",
 		"abc123def456",
 	} {
 		if !strings.Contains(got, want) {
@@ -65,7 +65,7 @@ func TestComposeTargetInDirMatchesMMTLCompose(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(`
 services:
   mmtl:
-    image: ghcr.io/shukebta/mmtl:latest
+    image: ghcr.io/truewhile/mmtl:latest
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

更新项目文档与 Docker 部署镜像，使其与 `truewhile/MMTL` fork 仓库一致。

## 主要变更

### README
- 明确 fork 自 MediaStationGo，更新当前功能描述
- 鸣谢 MediaStationGo 与 qmediasync
- 统一仓库与镜像地址为 `truewhile/MMTL`、`ghcr.io/truewhile/mmtl:latest`

### Docker Compose 与镜像
- 四份 `docker-compose*.yml` 镜像改为 `ghcr.io/truewhile/mmtl:latest`
- `MMTL_UPDATE_IMAGE` 同步更新
- 移除原项目 `shukebta` / `shukbet` 引用
- `system_update.go` 默认更新镜像与 `SECURITY.md` 一并修改

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c8807d5-1d9f-477e-aa8d-0149193caf8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c8807d5-1d9f-477e-aa8d-0149193caf8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

