### PR TITLE
fix(layout): 窄屏侧栏隐藏重复的媒体导航

### DIFF
--- a/web/src/components/LayoutSidebarContent.tsx
+++ b/web/src/components/LayoutSidebarContent.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 
 import {
   LAYOUT_NAV_ITEMS,
-  MEDIA_NAV_ITEMS,
   type LayoutNavItem,
 } from './layoutNavigation'
 import { SidebarLink } from './LayoutSidebarNav'
@@ -30,7 +29,6 @@ export function LayoutSidebarContent({
   variant = 'admin',
 }: LayoutSidebarContentProps) {
   const sidebarExpanded = isSidebarOpen || isMobileDrawerOpen
-  const mediaItems = visibleSidebarItems({ isAdmin, can, items: MEDIA_NAV_ITEMS })
   const adminItems = visibleSidebarItems({ isAdmin, can, items: LAYOUT_NAV_ITEMS })
 
   return (
@@ -41,19 +39,10 @@ export function LayoutSidebarContent({
         onCloseMobileDrawer={onCloseMobileDrawer}
       />
       <div className="min-h-0 flex-1 overflow-y-auto scrollbar-hide">
-        {variant === 'media' ? (
-          <>
-            <LayoutSidebarNav items={mediaItems} sidebarExpanded={sidebarExpanded} />
-            {adminItems.length > 0 && (
-              <div className="border-t border-[var(--app-border)]">
-                <LayoutSidebarSectionLabel sidebarExpanded={sidebarExpanded} label="管理" />
-                <LayoutSidebarNav items={adminItems} sidebarExpanded={sidebarExpanded} compactTop />
-              </div>
-            )}
-          </>
-        ) : (
+        {/* 窄屏媒体浏览抽屉不展示 MEDIA_NAV_ITEMS：底部导航与用户菜单已覆盖 */}
+        {variant !== 'media' || adminItems.length > 0 ? (
           <LayoutSidebarNav items={adminItems} sidebarExpanded={sidebarExpanded} />
-        )}
+        ) : null}
       </div>
       <LayoutSidebarHomeBack sidebarExpanded={sidebarExpanded} />
     </div>
@@ -107,37 +96,15 @@ function LayoutSidebarHeader({
   )
 }
 
-function LayoutSidebarSectionLabel({
-  sidebarExpanded,
-  label,
-}: {
-  sidebarExpanded: boolean
-  label: string
-}) {
-  if (!sidebarExpanded) return null
-  return (
-    <p className="px-4 pt-4 pb-1 text-[10px] font-bold uppercase tracking-wider text-[var(--app-muted)]">
-      {label}
-    </p>
-  )
-}
-
 function LayoutSidebarNav({
   items,
   sidebarExpanded,
-  compactTop = false,
 }: {
   items: LayoutNavItem[]
   sidebarExpanded: boolean
-  compactTop?: boolean
 }) {
   return (
-    <nav
-      className={clsx(
-        'px-4 py-5 space-y-1',
-        compactTop && 'pt-2',
-      )}
-    >
+    <nav className="px-4 py-5 space-y-1">
       {items.map((item) => {
         const ItemIcon = item.icon
         return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

窄屏模式下，侧栏抽屉顶部的「首页 / 媒体库 / 我的收藏 / 播放列表 / 观看历史」与底部导航栏、右上角用户菜单重复。

## 变更

- 媒体浏览场景（`variant=media`）的移动端抽屉不再展示 `MEDIA_NAV_ITEMS`
- 抽屉仅保留管理相关入口（个人资料、任务队列、系统设置等）
- 媒体浏览仍通过底部导航与用户菜单访问

## 测试

- `npm --prefix web run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c25ef491-b756-49de-ba20-554db44bc9cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c25ef491-b756-49de-ba20-554db44bc9cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

