### PR TITLE
Remove obsolete file manager organize options

### DIFF
--- a/web/src/pages/AutoOrganizeSettingsPanel.tsx
+++ b/web/src/pages/AutoOrganizeSettingsPanel.tsx
@@ -18,7 +18,6 @@ type AutoOrganizeSettingsPanelProps = {
   loading: boolean
   saving: boolean
   running: boolean
-  moveKeepsSeeding: boolean
   onRefresh: () => void
   onSave: () => void
   onRunNow: () => void
@@ -40,7 +39,6 @@ export function AutoOrganizeSettingsPanel({
   loading,
   saving,
   running,
-  moveKeepsSeeding,
   onRefresh,
   onSave,
   onRunNow,
@@ -108,7 +106,6 @@ export function AutoOrganizeSettingsPanel({
         <AutoOrganizeBasicTab
           config={config}
           currentDir={currentDir}
-          moveKeepsSeeding={moveKeepsSeeding}
           onConfigChange={onConfigChange}
         />
       )}

--- a/web/src/pages/AutoOrganizeSettingsTabs.tsx
+++ b/web/src/pages/AutoOrganizeSettingsTabs.tsx
@@ -13,11 +13,9 @@ type AutoOrganizeTabProps = {
 export function AutoOrganizeBasicTab({
   config,
   currentDir,
-  moveKeepsSeeding,
   onConfigChange,
 }: AutoOrganizeTabProps & {
   currentDir: string
-  moveKeepsSeeding: boolean
 }) {
   return (
     <>
@@ -68,7 +66,7 @@ export function AutoOrganizeBasicTab({
             onChange={(event) => onConfigChange('transferMode', event.target.value)}
           >
             <option value="hardlink">硬链接</option>
-            <option value="move">移动（关闭保种才会移动）</option>
+            <option value="move">移动</option>
             <option value="copy">复制</option>
             <option value="symlink">软链接</option>
           </select>
@@ -85,20 +83,10 @@ export function AutoOrganizeBasicTab({
         </label>
       </div>
 
-      {moveKeepsSeeding && (
-        <div className="rounded-xl border border-orange-300 bg-orange-50 px-3 py-2 text-xs text-orange-700">
-          当前同时选择了“移动”和“保种”。为避免 qB 做种源文件被删除，后端会实际使用硬链接；Docker / NAS
-          多挂载或不同子卷下可能报 invalid cross-device link。需要真正移动时请关闭“保种”，需要保种但硬链接失败时请选择“复制”。
-        </div>
-      )}
-
       <div className="flex flex-wrap items-center gap-3">
         <BooleanSetting config={config} settingKey="enabled" label="整理源目录定时自动整理" onConfigChange={onConfigChange} />
-        <BooleanSetting config={config} settingKey="afterDownload" label="qB 下载完成后自动整理" onConfigChange={onConfigChange} />
-        <BooleanSetting config={config} settingKey="downloadSmartClassify" label="下载器智能分类" onConfigChange={onConfigChange} />
         <BooleanSetting config={config} settingKey="smartClassify" label="智能分类到子库" onConfigChange={onConfigChange} />
         <BooleanSetting config={config} settingKey="autoAddLibrary" label="自动注册目的地媒体库" onConfigChange={onConfigChange} />
-        <BooleanSetting config={config} settingKey="keepSeeding" label="保种" onConfigChange={onConfigChange} />
       </div>
     </>
   )

--- a/web/src/pages/FileManagerPage.tsx
+++ b/web/src/pages/FileManagerPage.tsx
@@ -4,7 +4,6 @@ import { ChevronUp, Home } from 'lucide-react'
 import { filesAPI, type FileEntry, type FileListing } from '../api/files'
 import { libraryAPI } from '../api/library'
 import type { Library } from '../types'
-import { settingOn } from './autoOrganizeModel'
 import { AutoOrganizeSettingsPanel } from './AutoOrganizeSettingsPanel'
 import { FileBrowserRoots } from './FileBrowserRoots'
 import { FileEntriesTable } from './FileEntriesTable'
@@ -36,7 +35,6 @@ export function FileManagerPage() {
     () => libraries.filter((library) => !isCloudLibraryPath(library.path)),
     [libraries],
   )
-  const autoMoveKeepsSeeding = autoOrganize.moveKeepsSeeding
 
   const refresh = useCallback(() => {
     setLoading(true)
@@ -68,7 +66,6 @@ export function FileManagerPage() {
     selectedPath: fileOperations.selected?.path,
     selectedPaths: fileOperations.selectedPaths,
     scrapeAfter,
-    keepSeeding: settingOn(autoOrganize.config.keepSeeding),
     onScrapeAfterChange: setScrapeAfter,
     onClearSelected: () => fileOperations.setSelectedPaths([]),
     refresh,
@@ -102,7 +99,6 @@ export function FileManagerPage() {
         loading={autoOrganize.loading}
         saving={autoOrganize.saving}
         running={autoOrganize.running}
-        moveKeepsSeeding={autoMoveKeepsSeeding}
         onRefresh={autoOrganize.refresh}
         onSave={() => void autoOrganize.save()}
         onRunNow={autoOrganize.runNow}
@@ -119,7 +115,6 @@ export function FileManagerPage() {
           organizeDestPath={manualOrganize.organizeDestPath}
           organizeMediaType={manualOrganize.organizeMediaType}
           organizeTransferMode={manualOrganize.organizeTransferMode}
-          manualMoveKeepsSeeding={manualOrganize.manualMoveKeepsSeeding}
           scanAfter={manualOrganize.scanAfter}
           scrapeAfter={scrapeAfter}
           organizeReady={manualOrganize.organizeReady}

--- a/web/src/pages/ManualOrganizePanel.tsx
+++ b/web/src/pages/ManualOrganizePanel.tsx
@@ -15,7 +15,6 @@ type ManualOrganizePanelProps = {
   organizeDestPath: string
   organizeMediaType: string
   organizeTransferMode: string
-  manualMoveKeepsSeeding: boolean
   scanAfter: boolean
   scrapeAfter: boolean
   organizeReady: boolean
@@ -40,7 +39,6 @@ export function ManualOrganizePanel({
   organizeDestPath,
   organizeMediaType,
   organizeTransferMode,
-  manualMoveKeepsSeeding,
   scanAfter,
   scrapeAfter,
   organizeReady,
@@ -119,18 +117,12 @@ export function ManualOrganizePanel({
           <span className="text-xs text-ink-50">整理方式</span>
           <select className="input-base w-full" value={organizeTransferMode} onChange={(event) => onTransferModeChange(event.target.value)}>
             <option value="hardlink">硬链接</option>
-            <option value="move">移动（关闭保种才会移动）</option>
+            <option value="move">移动</option>
             <option value="copy">复制</option>
             <option value="symlink">软链接</option>
           </select>
         </label>
       </div>
-
-      {manualMoveKeepsSeeding && (
-        <div className="rounded-xl border border-orange-300 bg-orange-50 px-3 py-2 text-xs text-orange-700">
-          “保种”已开启，选择“移动”时后端会改用硬链接以保留下载源。要执行真正移动，请先在上方自动整理设置里关闭“保种”并保存。
-        </div>
-      )}
 
       <div className="flex flex-wrap items-center gap-2">
         <label className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-2 py-1 text-xs text-ink-100">

--- a/web/src/pages/autoOrganizeModel.ts
+++ b/web/src/pages/autoOrganizeModel.ts
@@ -2,16 +2,13 @@ import type { Setting } from '../types'
 
 export type AutoOrganizeConfig = {
   enabled: string
-  afterDownload: string
   scrapeAfter: string
-  downloadSmartClassify: string
   smartClassify: string
   autoAddLibrary: string
   sourceDir: string
   targetDir: string
   transferMode: string
   intervalSeconds: string
-  keepSeeding: string
   movieFormat: string
   tvFormat: string
   animeFormat: string
@@ -24,16 +21,13 @@ export type AutoOrganizeConfig = {
 
 export const AUTO_ORGANIZE_DEFAULTS: AutoOrganizeConfig = {
   enabled: 'false',
-  afterDownload: 'false',
   scrapeAfter: 'true',
-  downloadSmartClassify: 'true',
   smartClassify: 'true',
   autoAddLibrary: 'true',
   sourceDir: '',
   targetDir: '',
   transferMode: 'hardlink',
   intervalSeconds: '300',
-  keepSeeding: 'true',
   movieFormat: '{title} ({year})/{title} ({year})',
   tvFormat: '{title} ({year})/Season {season:02}/{title} S{season:02}E{episode:02}',
   animeFormat: '{title}/Season {season:02}/{title} S{season:02}E{episode:02}',
@@ -46,16 +40,13 @@ export const AUTO_ORGANIZE_DEFAULTS: AutoOrganizeConfig = {
 
 export const AUTO_ORGANIZE_KEYS: Record<keyof AutoOrganizeConfig, string> = {
   enabled: 'organize.auto',
-  afterDownload: 'organizer.auto_after_download',
   scrapeAfter: 'organize.scrape_after',
-  downloadSmartClassify: 'downloads.smart_classify',
   smartClassify: 'organizer.smart_classify',
   autoAddLibrary: 'organize.auto_add_library',
   sourceDir: 'organize.source_dir',
   targetDir: 'organize.target_dir',
   transferMode: 'organize.transfer_mode',
   intervalSeconds: 'organize.interval_seconds',
-  keepSeeding: 'organize.keep_seeding',
   movieFormat: 'organize.movie_format',
   tvFormat: 'organize.tv_format',
   animeFormat: 'organize.anime_format',
@@ -72,16 +63,13 @@ export function mergeAutoOrganizeSettings(rows: Setting[]): AutoOrganizeConfig {
   const idx = settingIndex(rows)
   return {
     enabled: idx[AUTO_ORGANIZE_KEYS.enabled] ?? AUTO_ORGANIZE_DEFAULTS.enabled,
-    afterDownload: idx[AUTO_ORGANIZE_KEYS.afterDownload] ?? AUTO_ORGANIZE_DEFAULTS.afterDownload,
     scrapeAfter: idx[AUTO_ORGANIZE_KEYS.scrapeAfter] ?? AUTO_ORGANIZE_DEFAULTS.scrapeAfter,
-    downloadSmartClassify: idx[AUTO_ORGANIZE_KEYS.downloadSmartClassify] ?? AUTO_ORGANIZE_DEFAULTS.downloadSmartClassify,
     smartClassify: idx[AUTO_ORGANIZE_KEYS.smartClassify] ?? AUTO_ORGANIZE_DEFAULTS.smartClassify,
     autoAddLibrary: idx[AUTO_ORGANIZE_KEYS.autoAddLibrary] ?? AUTO_ORGANIZE_DEFAULTS.autoAddLibrary,
     sourceDir: idx[AUTO_ORGANIZE_KEYS.sourceDir] ?? AUTO_ORGANIZE_DEFAULTS.sourceDir,
     targetDir: idx[AUTO_ORGANIZE_KEYS.targetDir] ?? AUTO_ORGANIZE_DEFAULTS.targetDir,
     transferMode: idx[AUTO_ORGANIZE_KEYS.transferMode] ?? AUTO_ORGANIZE_DEFAULTS.transferMode,
     intervalSeconds: idx[AUTO_ORGANIZE_KEYS.intervalSeconds] ?? AUTO_ORGANIZE_DEFAULTS.intervalSeconds,
-    keepSeeding: idx[AUTO_ORGANIZE_KEYS.keepSeeding] ?? AUTO_ORGANIZE_DEFAULTS.keepSeeding,
     movieFormat: idx[AUTO_ORGANIZE_KEYS.movieFormat] ?? AUTO_ORGANIZE_DEFAULTS.movieFormat,
     tvFormat: idx[AUTO_ORGANIZE_KEYS.tvFormat] ?? AUTO_ORGANIZE_DEFAULTS.tvFormat,
     animeFormat: idx[AUTO_ORGANIZE_KEYS.animeFormat] ?? AUTO_ORGANIZE_DEFAULTS.animeFormat,

--- a/web/src/pages/useAutoOrganizeSettings.ts
+++ b/web/src/pages/useAutoOrganizeSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 
 import { adminAPI } from '../api/admin'
@@ -79,11 +79,6 @@ export function useAutoOrganizeSettings({ onScrapeAfterChange }: UseAutoOrganize
     }
   }, [dirty, save])
 
-  const moveKeepsSeeding = useMemo(
-    () => config.transferMode === 'move' && settingOn(config.keepSeeding),
-    [config.keepSeeding, config.transferMode],
-  )
-
   return {
     config,
     dirty,
@@ -91,7 +86,6 @@ export function useAutoOrganizeSettings({ onScrapeAfterChange }: UseAutoOrganize
     running,
     loading,
     activeTab,
-    moveKeepsSeeding,
     refresh,
     save,
     runNow,

--- a/web/src/pages/useManualOrganize.ts
+++ b/web/src/pages/useManualOrganize.ts
@@ -17,7 +17,6 @@ type UseManualOrganizeOptions = {
   selectedPath?: string
   selectedPaths: string[]
   scrapeAfter: boolean
-  keepSeeding: boolean
   onScrapeAfterChange: (value: boolean) => void
   onClearSelected: () => void
   refresh: () => void
@@ -29,7 +28,6 @@ export function useManualOrganize({
   selectedPath,
   selectedPaths,
   scrapeAfter,
-  keepSeeding,
   onScrapeAfterChange,
   onClearSelected,
   refresh,
@@ -59,7 +57,6 @@ export function useManualOrganize({
   )
   const organizeSource = organizeSources.length === 1 ? organizeSources[0] : `${organizeSources.length} 个已选项目`
   const organizeReady = organizeSources.length > 0 && Boolean(organizeDestPath.trim())
-  const manualMoveKeepsSeeding = organizeTransferMode === 'move' && keepSeeding
 
   const runManualOrganize = async (dryRun: boolean) => {
     if (!organizeReady) {
@@ -124,7 +121,6 @@ export function useManualOrganize({
     previewItems,
     organizeSource,
     organizeReady,
-    manualMoveKeepsSeeding,
     setOrganizeLibraryID,
     setOrganizeDestPath,
     setOrganizeTransferMode,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes three obsolete options from the file manager's auto-organize settings that no longer have backing functionality:

- **qB 下载完成后自动整理**
- **下载器智能分类**
- **保种**

Also cleans up related UI:

- Removed warning banners about move + seeding behavior
- Simplified transfer mode label from "移动（关闭保种才会移动）" to "移动"
- Stopped loading/saving these settings from the file manager settings panel

## Test plan

- [x] `npm run build` passes
- [ ] Open 文件管理 → 自动整理设置 and confirm only the remaining options are shown
- [ ] Confirm manual organize panel no longer shows seeding warning when selecting move
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eef18fb-69f5-47c2-95a6-928a5327826d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eef18fb-69f5-47c2-95a6-928a5327826d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

