### PR TITLE
Add library favourite buttons and fix remote favourites list

### DIFF
--- a/internal/service/emby_remote_web.go
+++ b/internal/service/emby_remote_web.go
@@ -300,6 +300,9 @@ func (r *EmbyRemoteService) MapRemoteItemToMedia(ctx context.Context, mount *mod
 		media.SeasonNum = 0
 		media.EpisodeNum = 0
 	}
+	if mount != nil && strings.TrimSpace(mount.RemoteViewID) != "" {
+		media.DisplayLibraryID = EncodeEmbyRemoteID(mount.ID, mount.RemoteViewID)
+	}
 	return media
 }
 

--- a/internal/service/playback.go
+++ b/internal/service/playback.go
@@ -9,6 +9,7 @@ package service
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 
 	"go.uber.org/zap"
@@ -126,14 +127,47 @@ func (p *PlaybackService) ListFavourites(ctx context.Context, userID string) ([]
 	if len(favs) == 0 {
 		return nil, nil
 	}
-	ids := make([]string, len(favs))
-	for i, f := range favs {
-		ids[i] = f.MediaID
+	sort.Slice(favs, func(i, j int) bool {
+		return favs[i].CreatedAt.After(favs[j].CreatedAt)
+	})
+
+	localIDs := make([]string, 0, len(favs))
+	for _, fav := range favs {
+		if !IsEmbyRemoteID(fav.MediaID) {
+			localIDs = append(localIDs, fav.MediaID)
+		}
 	}
-	var out []model.Media
-	err = p.repo.DB.Where("id IN ?", ids).
-		Order("created_at desc").Find(&out).Error
-	return out, err
+	mediaByID := map[string]model.Media{}
+	if len(localIDs) > 0 {
+		var mediaRows []model.Media
+		if err := p.repo.DB.WithContext(ctx).Where("id IN ?", localIDs).Find(&mediaRows).Error; err != nil {
+			return nil, err
+		}
+		for _, media := range mediaRows {
+			mediaByID[media.ID] = media
+		}
+	}
+
+	out := make([]model.Media, 0, len(favs))
+	for _, fav := range favs {
+		if media, ok := mediaByID[fav.MediaID]; ok {
+			out = append(out, media)
+			continue
+		}
+		if p.remote != nil && IsEmbyRemoteID(fav.MediaID) {
+			mountID, remoteID, _ := DecodeEmbyRemoteID(fav.MediaID)
+			mount, acct, _ := p.remote.ResolveMount(ctx, mountID)
+			if mount == nil || acct == nil {
+				continue
+			}
+			remoteMedia, err := p.remote.RemoteMediaDetail(ctx, mount, acct, remoteID)
+			if err != nil || remoteMedia == nil {
+				continue
+			}
+			out = append(out, *remoteMedia)
+		}
+	}
+	return out, nil
 }
 
 // ─── Playlists ──────────────────────────────────────────────────────────────

--- a/internal/service/playback_test.go
+++ b/internal/service/playback_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ShukeBta/MMTL/internal/model"
+	"github.com/ShukeBta/MMTL/internal/repository"
+	"go.uber.org/zap"
+)
+
+func TestListFavouritesIncludesLocalAndRemoteIDs(t *testing.T) {
+	db := newServiceTestDB(t, &model.Favorite{}, &model.Media{})
+	repos := repository.New(db)
+	userID := "user-1"
+	local := model.Media{
+		Base:  model.Base{ID: "local-movie-1"},
+		Title: "Local Movie",
+	}
+	if err := db.Create(&local).Error; err != nil {
+		t.Fatalf("create local media: %v", err)
+	}
+	remoteID := EncodeEmbyRemoteID("mount-1", "remote-series-1")
+	favs := []model.Favorite{
+		{Base: model.Base{CreatedAt: time.Now().Add(-time.Minute)}, UserID: userID, MediaID: remoteID},
+		{Base: model.Base{CreatedAt: time.Now()}, UserID: userID, MediaID: local.ID},
+	}
+	for i := range favs {
+		if err := db.Create(&favs[i]).Error; err != nil {
+			t.Fatalf("create favorite %d: %v", i, err)
+		}
+	}
+
+	svc := NewPlaybackService(zap.NewNop(), repos)
+	items, err := svc.ListFavourites(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListFavourites: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one hydrated local favourite without remote service, got %d: %#v", len(items), items)
+	}
+	if items[0].ID != local.ID {
+		t.Fatalf("expected local favourite first by created_at desc, got %#v", items[0])
+	}
+}

--- a/web/src/components/MediaFavouriteButton.tsx
+++ b/web/src/components/MediaFavouriteButton.tsx
@@ -1,0 +1,57 @@
+import { Heart } from 'lucide-react'
+
+type MediaFavouriteButtonProps = {
+  favourite: boolean
+  onToggle: () => void
+  disabled?: boolean
+  variant?: 'compact' | 'inline'
+  className?: string
+}
+
+export function MediaFavouriteButton({
+  favourite,
+  onToggle,
+  disabled = false,
+  variant = 'inline',
+  className = '',
+}: MediaFavouriteButtonProps) {
+  if (variant === 'compact') {
+    return (
+      <button
+        type="button"
+        title={favourite ? '取消收藏' : '加入收藏'}
+        disabled={disabled}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onToggle()
+        }}
+        className={
+          'flex h-8 w-8 items-center justify-center rounded-lg border border-white/70 bg-white/90 shadow-sm backdrop-blur transition hover:bg-red-50 disabled:opacity-50 ' +
+          (favourite ? 'text-red-500' : 'text-gray-700 hover:text-red-500') +
+          (className ? ` ${className}` : '')
+        }
+      >
+        <Heart size={13} fill={favourite ? 'currentColor' : 'none'} />
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onToggle}
+      className={
+        'btn-outline gap-2 ' +
+        (favourite
+          ? '!border-red-200 !bg-red-50 !text-red-600 hover:!bg-red-100/50'
+          : 'hover:border-red-200 hover:text-red-600 hover:bg-red-50/50') +
+        (className ? ` ${className}` : '')
+      }
+    >
+      <Heart size={14} fill={favourite ? 'currentColor' : 'none'} />
+      <span>{favourite ? '取消收藏' : '加入收藏'}</span>
+    </button>
+  )
+}

--- a/web/src/hooks/useFavourites.ts
+++ b/web/src/hooks/useFavourites.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { playbackAPI } from '../api/playback'
+
+export function useFavourites() {
+  const [favouriteIDs, setFavouriteIDs] = useState<Set<string>>(() => new Set())
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    playbackAPI
+      .listFavourites()
+      .then((items) => {
+        if (!cancelled) {
+          setFavouriteIDs(new Set((items ?? []).map((item) => item.id)))
+        }
+      })
+      .catch(() => {
+        if (!cancelled) toast.error('加载收藏状态失败')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isFavourite = useCallback((mediaID: string) => favouriteIDs.has(mediaID), [favouriteIDs])
+
+  const toggleFavourite = useCallback(async (mediaID: string) => {
+    try {
+      const state = await playbackAPI.toggleFavourite(mediaID)
+      setFavouriteIDs((current) => {
+        const next = new Set(current)
+        if (state) next.add(mediaID)
+        else next.delete(mediaID)
+        return next
+      })
+      toast.success(state ? '已加入我的收藏' : '已取消收藏')
+      return state
+    } catch {
+      toast.error('收藏操作失败')
+      return favouriteIDs.has(mediaID)
+    }
+  }, [favouriteIDs])
+
+  return { isFavourite, toggleFavourite, loading }
+}

--- a/web/src/pages/FavouritesPage.tsx
+++ b/web/src/pages/FavouritesPage.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 import { playbackAPI } from '../api/playback'
 import { MediaCard } from '../components/MediaCard'
 import type { Media } from '../types'
+import { favouriteMediaLink } from '../utils/mediaNavigation'
 
 export function FavouritesPage() {
   const [items, setItems] = useState<Media[]>([])
@@ -66,7 +67,7 @@ export function FavouritesPage() {
         <div className="glass-panel flex flex-col items-center gap-3 p-10 text-center">
           <p className="text-lg text-ink-100">还没有任何收藏</p>
           <p className="text-sm text-sand-500">
-            点击媒体详情页的「收藏」按钮添加喜欢的内容
+            在媒体库或详情页点击「加入收藏」即可添加喜欢的内容
           </p>
         </div>
       )}
@@ -74,7 +75,7 @@ export function FavouritesPage() {
       {items.length > 0 && (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {items.map((m) => (
-            <MediaCard key={m.id} media={m} />
+            <MediaCard key={m.id} media={m} linkTo={favouriteMediaLink(m)} />
           ))}
         </div>
       )}

--- a/web/src/pages/LibraryMediaSections.tsx
+++ b/web/src/pages/LibraryMediaSections.tsx
@@ -11,7 +11,7 @@ type LibraryMediaSectionsProps = {
   seriesCards: SeriesCard[]
   selectedSeries: SeriesCard | null
   loading: boolean
-  movieActions: (media: Media) => ReactNode
+  cardActions: (media: Media) => ReactNode
   onSeriesClick: (series: SeriesCard) => void
 }
 
@@ -21,7 +21,7 @@ export function LibraryMediaSections({
   seriesCards,
   selectedSeries,
   loading,
-  movieActions,
+  cardActions,
   onSeriesClick,
 }: LibraryMediaSectionsProps) {
   return (
@@ -29,7 +29,7 @@ export function LibraryMediaSections({
       {!isSeries && items.length > 0 && (
         <div className="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-8">
           {items.map((media) => (
-            <MediaCard key={media.id} media={media} actions={movieActions(media)} />
+            <MediaCard key={media.id} media={media} actions={cardActions(media)} />
           ))}
         </div>
       )}
@@ -45,6 +45,7 @@ export function LibraryMediaSections({
               key={series.key}
               media={series.rep}
               count={series.count}
+              actions={cardActions(series.rep)}
               onClick={() => onSeriesClick(series)}
             />
           ))}

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, Fragment, type ReactNode } from 'react'
 import { useLocation, useParams, useSearchParams } from 'react-router-dom'
 import { motion } from 'framer-motion'
 
@@ -14,6 +14,7 @@ import {
 } from '../utils/mediaSort'
 import { LibraryPageDialogs } from './LibraryPageDialogs'
 import { PageBackButton } from '../components/PageBackButton'
+import { MediaFavouriteButton } from '../components/MediaFavouriteButton'
 import { LibraryPageHeader } from './LibraryPageHeader'
 import { LibraryMediaSections } from './LibraryMediaSections'
 import { LibrarySeriesDetailSection } from './LibrarySeriesDetailSection'
@@ -21,12 +22,17 @@ import { useLibraryData } from './useLibraryData'
 import { useLibraryScanStatus } from './useLibraryScanStatus'
 import { useLibrarySeriesSelection } from './useLibrarySeriesSelection'
 import { useLibraryAdminActions } from './useLibraryAdminActions'
+import { usePermission } from '../hooks/usePermission'
+import { useFavourites } from '../hooks/useFavourites'
 
 export function LibraryPage() {
   const { id = '' } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
   const role = useAuthStore((s) => s.user?.role)
+  const canFavorite = usePermission('can_favorite')
+  const { isFavourite, toggleFavourite } = useFavourites()
+  const [favouriteBusyID, setFavouriteBusyID] = useState('')
 
   const [scrapeDialogOpen, setScrapeDialogOpen] = useState(false)
   const [manualSeriesScrapeOpen, setManualSeriesScrapeOpen] = useState(false)
@@ -169,6 +175,39 @@ export function LibraryPage() {
     setManualMovie,
   })
 
+  const handleToggleFavourite = async (mediaID: string) => {
+    if (!canFavorite || favouriteBusyID) return
+    setFavouriteBusyID(mediaID)
+    try {
+      await toggleFavourite(mediaID)
+    } finally {
+      setFavouriteBusyID('')
+    }
+  }
+
+  const cardActions = (media: Media): ReactNode => {
+    const actions: ReactNode[] = []
+    if (canFavorite) {
+      actions.push(
+        <MediaFavouriteButton
+          key="favourite"
+          variant="compact"
+          favourite={isFavourite(media.id)}
+          disabled={favouriteBusyID === media.id}
+          onToggle={() => {
+            void handleToggleFavourite(media.id)
+          }}
+        />,
+      )
+    }
+    const adminActions = movieActions(media)
+    if (adminActions) {
+      actions.push(<Fragment key="admin-actions">{adminActions}</Fragment>)
+    }
+    if (actions.length === 0) return undefined
+    return <>{actions}</>
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-32">
@@ -216,7 +255,7 @@ export function LibraryPage() {
         seriesCards={sortedSeriesCards}
         selectedSeries={selectedSeries}
         loading={loading}
-        movieActions={movieActions}
+        cardActions={cardActions}
         onSeriesClick={handleSeriesClick}
       />
 
@@ -229,6 +268,13 @@ export function LibraryPage() {
         loadingEpisodes={loadingSeriesEpisodes}
         playbackFrom={`${location.pathname}${location.search}`}
         isAdmin={role === 'admin'}
+        canFavorite={canFavorite}
+        favourite={selectedSeries ? isFavourite(selectedSeries.rep.id) : false}
+        favouriteBusy={!!selectedSeries && favouriteBusyID === selectedSeries.rep.id}
+        onToggleFavourite={() => {
+          if (!selectedSeries) return
+          void handleToggleFavourite(selectedSeries.rep.id)
+        }}
         seriesToolBusy={seriesToolBusy}
         onBack={clearSelectedSeries}
         onSmartScrape={handleSeriesSmartScrape}

--- a/web/src/pages/LibrarySeriesDetailHeader.tsx
+++ b/web/src/pages/LibrarySeriesDetailHeader.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Database, FileText, Film, FolderInput, Pencil, Play, Search,
 
 import { imageURL } from '../api/client'
 import { ExternalPlayerButton } from '../components/ExternalPlayerButton'
+import { MediaFavouriteButton } from '../components/MediaFavouriteButton'
 import type { Media } from '../types'
 import { seriesTitle, type SeriesCard } from '../utils/groupSeries'
 
@@ -13,6 +14,10 @@ type LibrarySeriesDetailHeaderProps = {
   allEpisodes: Media[]
   playbackFrom: string
   isAdmin: boolean
+  canFavorite: boolean
+  favourite: boolean
+  favouriteBusy: boolean
+  onToggleFavourite: () => void
   seriesToolBusy: string
   onBack: () => void
   onSmartScrape: () => void
@@ -30,6 +35,10 @@ export function LibrarySeriesDetailHeader({
   allEpisodes,
   playbackFrom,
   isAdmin,
+  canFavorite,
+  favourite,
+  favouriteBusy,
+  onToggleFavourite,
   seriesToolBusy,
   onBack,
   onSmartScrape,
@@ -75,15 +84,24 @@ export function LibrarySeriesDetailHeader({
             {series.rep.overview || '暂无简介'}
           </p>
 
-          {firstEpisode && (
-            <div className="flex flex-wrap gap-2">
-              <Link to={`/play/${firstEpisode.id}`} state={{ from: playbackFrom }} className="btn-primary inline-flex">
-                <Play size={16} fill="currentColor" />
-                从第一集开始播放
-              </Link>
-              <ExternalPlayerButton mediaId={firstEpisode.id} label="外部播放器播放" />
-            </div>
-          )}
+          <div className="flex flex-wrap gap-2">
+            {firstEpisode && (
+              <>
+                <Link to={`/play/${firstEpisode.id}`} state={{ from: playbackFrom }} className="btn-primary inline-flex">
+                  <Play size={16} fill="currentColor" />
+                  从第一集开始播放
+                </Link>
+                <ExternalPlayerButton mediaId={firstEpisode.id} label="外部播放器播放" />
+              </>
+            )}
+            {canFavorite && (
+              <MediaFavouriteButton
+                favourite={favourite}
+                disabled={favouriteBusy}
+                onToggle={onToggleFavourite}
+              />
+            )}
+          </div>
 
           {isAdmin && allEpisodes.length > 0 && !isRemoteEmbyID(series.rep.id) && (
             <div className="rounded-2xl border border-sand-200 bg-white/80 p-4 shadow-sm">

--- a/web/src/pages/LibrarySeriesDetailSection.tsx
+++ b/web/src/pages/LibrarySeriesDetailSection.tsx
@@ -19,6 +19,10 @@ type LibrarySeriesDetailSectionProps = {
   loadingEpisodes: boolean
   playbackFrom: string
   isAdmin: boolean
+  canFavorite: boolean
+  favourite: boolean
+  favouriteBusy: boolean
+  onToggleFavourite: () => void
   seriesToolBusy: string
   onBack: () => void
   onSmartScrape: () => void
@@ -40,6 +44,10 @@ export function LibrarySeriesDetailSection({
   loadingEpisodes,
   playbackFrom,
   isAdmin,
+  canFavorite,
+  favourite,
+  favouriteBusy,
+  onToggleFavourite,
   seriesToolBusy,
   onBack,
   onSmartScrape,
@@ -66,6 +74,10 @@ export function LibrarySeriesDetailSection({
             allEpisodes={allEpisodes}
             playbackFrom={playbackFrom}
             isAdmin={isAdmin}
+            canFavorite={canFavorite}
+            favourite={favourite}
+            favouriteBusy={favouriteBusy}
+            onToggleFavourite={onToggleFavourite}
             seriesToolBusy={seriesToolBusy}
             onBack={onBack}
             onSmartScrape={onSmartScrape}

--- a/web/src/pages/MediaDetailPageModel.ts
+++ b/web/src/pages/MediaDetailPageModel.ts
@@ -1,14 +1,13 @@
 import type { Media } from '../types'
-import { getSeriesKey, isEpisodeLike } from '../utils/groupSeries'
+import { mediaLibraryTarget } from '../utils/mediaNavigation'
 
 export function mediaLibraryBackTarget(media: Media): string {
+  const seriesTarget = mediaLibraryTarget(media)
+  if (seriesTarget) return seriesTarget
+
   const libraryID = media.display_library_id || media.library_id
   if (!libraryID) return ''
-  if (!isEpisodeLike(media)) return `/library/${encodeURIComponent(libraryID)}`
-
-  const seriesKey = getSeriesKey(media)
-  const target = `/library/${encodeURIComponent(libraryID)}`
-  return seriesKey ? `${target}?series=${encodeURIComponent(seriesKey)}` : target
+  return `/library/${encodeURIComponent(libraryID)}`
 }
 
 export function mediaDetailScrapeMediaType(media: Media): string | undefined {

--- a/web/src/utils/groupSeries.ts
+++ b/web/src/utils/groupSeries.ts
@@ -89,7 +89,7 @@ const EPISODIC_PATH_RE =
 const SEASON_FOLDER_RE =
   /^(?:s\d{1,2}|season[\s._-]*\d{1,2}|第\s*[0-9一二三四五六七八九十百零两]+\s*季|special[\s._-]*episodes?|specials?|sp|ovas?|oads?|extras?|bonus(?:es)?|omake|特别篇|特別篇|番外篇?|特典|外传|外傳|总集篇|總集篇)$/i
 
-function pathLooksEpisodic(media: Media): boolean {
+export function pathLooksEpisodic(media: Media): boolean {
   const path = (media.path || media.display_library_path || media.library_path || '')
   return EPISODIC_PATH_RE.test(path)
 }

--- a/web/src/utils/groupSeries.ts
+++ b/web/src/utils/groupSeries.ts
@@ -84,7 +84,7 @@ export function isEpisodeLike(media: Media): boolean {
 // 剧集类目录名(电视剧/动漫及其二级分类)。媒体路径落在这些目录下时, 即便
 // 季集号未识别出来, 也应按剧集对待, 跳转到 /library 分类视图而非 /media 单页。
 const EPISODIC_PATH_RE =
-  /[\\/](?:电视剧|剧集|连续剧|短剧|国产剧|国剧|大陆剧|华语剧|国产电视剧|大陆电视剧|华语电视剧|欧美剧|欧美电视剧|美剧|英剧|日韩剧|日韩电视剧|日剧|韩剧|港剧|台剧|港台剧|泰剧|综艺|纪录片|儿童|动漫|番剧|国漫|日番|韩漫|美漫|欧美动漫|欧美动画|其他动漫|tv|series|shows?|season[\s._-]*\d|s\d{1,2}(?:[\s._-]|[\\/])|special[\s._-]*episodes?|specials?|sp|ovas?|oads?|extras?|bonus(?:es)?|omake|特别篇|特別篇|番外篇?|特典|外传|外傳|总集篇|總集篇)[\\/]/i
+  /[\\/](?:电视剧|剧集|连续剧|短剧|国产剧|国剧|大陆剧|华语剧|国产电视剧|大陆电视剧|华语电视剧|欧美剧|欧美电视剧|美剧|英剧|日韩剧|日韩电视剧|日剧|韩剧|港剧|台剧|港台剧|泰剧|综艺|纪录片|儿童|动漫|番剧|国漫|日番|韩漫|美漫|欧美动漫|欧美动画|其他动漫|anime|tv|series|shows?|season[\s._-]*\d|s\d{1,2}(?:[\s._-]|[\\/])|special[\s._-]*episodes?|specials?|sp|ovas?|oads?|extras?|bonus(?:es)?|omake|特别篇|特別篇|番外篇?|特典|外传|外傳|总集篇|總集篇)[\\/]/i
 
 const SEASON_FOLDER_RE =
   /^(?:s\d{1,2}|season[\s._-]*\d{1,2}|第\s*[0-9一二三四五六七八九十百零两]+\s*季|special[\s._-]*episodes?|specials?|sp|ovas?|oads?|extras?|bonus(?:es)?|omake|特别篇|特別篇|番外篇?|特典|外传|外傳|总集篇|總集篇)$/i

--- a/web/src/utils/mediaNavigation.ts
+++ b/web/src/utils/mediaNavigation.ts
@@ -2,11 +2,24 @@ import type { Media } from '../types'
 import { isRemoteEmbyID } from './remoteEmby'
 import { getSeriesKey, isEpisodeLike, pathLooksEpisodic } from './groupSeries'
 
+function pathLooksLikeMovie(media: Media): boolean {
+  const path = (media.path || media.display_library_path || media.library_path || '').toLowerCase()
+  return /[\\/](?:movie|movies|film|films|电影)[\\/]/i.test(path)
+}
+
+function isRemoteEmbyLibrarySeries(media: Media): boolean {
+  if (!isRemoteEmbyID(media.id) || isEpisodeLike(media)) return false
+  const libraryID = media.display_library_id || media.library_id
+  if (!libraryID) return false
+  return !pathLooksLikeMovie(media)
+}
+
 /** Whether opening the library series detail view is a better target than /media/:id. */
 export function prefersLibrarySeriesView(media: Media): boolean {
   if (isEpisodeLike(media)) return true
   if (pathLooksEpisodic(media)) return true
   if (media.series_id) return true
+  if (isRemoteEmbyLibrarySeries(media)) return true
   return false
 }
 

--- a/web/src/utils/mediaNavigation.ts
+++ b/web/src/utils/mediaNavigation.ts
@@ -1,0 +1,34 @@
+import type { Media } from '../types'
+import { isRemoteEmbyID } from './remoteEmby'
+import { getSeriesKey, isEpisodeLike, pathLooksEpisodic } from './groupSeries'
+
+/** Whether opening the library series detail view is a better target than /media/:id. */
+export function prefersLibrarySeriesView(media: Media): boolean {
+  if (isEpisodeLike(media)) return true
+  if (pathLooksEpisodic(media)) return true
+  if (media.series_id) return true
+  return false
+}
+
+/** Series key used by /library/:id?series=... for both local and remote libraries. */
+export function resolveLibrarySeriesKey(media: Media): string {
+  if (isRemoteEmbyID(media.id) && !isEpisodeLike(media)) {
+    return media.id
+  }
+  return getSeriesKey(media)
+}
+
+/** Best library URL for a media item, or null when /media/:id is preferred. */
+export function mediaLibraryTarget(media: Media): string | null {
+  const libraryID = media.display_library_id || media.library_id
+  if (!libraryID || !prefersLibrarySeriesView(media)) return null
+
+  const seriesKey = resolveLibrarySeriesKey(media)
+  const base = `/library/${encodeURIComponent(libraryID)}`
+  return seriesKey ? `${base}?series=${encodeURIComponent(seriesKey)}` : base
+}
+
+/** Link target for favourites / cards that should open the library series view when possible. */
+export function favouriteMediaLink(media: Media): string {
+  return mediaLibraryTarget(media) ?? `/media/${media.id}`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves favourites UX in the media library flow and fixes remote Emby favourites not appearing.

## Changes

- Library grid + series detail favourite buttons
- **Favourites navigation:** series/episodic favourites now open `/library/:id?series=...` instead of `/media/:id`
- **Backend:** remote favourites include `display_library_id` for correct library routing
- **Backend:** `ListFavourites` hydrates remote `embyremote~...` IDs

## Navigation rules

| Favourite type | Opens |
|---|---|
| TV/anime series (incl. remote Emby) | Library series detail with episodes |
| Single movie | Media detail page |

## Test plan

- [x] `npm --prefix web run build`
- [x] `go test ./internal/service -run TestListFavourites`
- [x] Verified favourites API returns `display_library_id` for remote items
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7af3b37e-e6ef-43d6-b2a7-2f161461ea2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7af3b37e-e6ef-43d6-b2a7-2f161461ea2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

