### PR TITLE
feat(strm): 同步目录本地输出路径自动拼接远端末级目录

### DIFF
--- a/web/src/pages/StrmDialogs.tsx
+++ b/web/src/pages/StrmDialogs.tsx
@@ -33,6 +33,7 @@ import {
   normalizeEmbyRemoteLines,
   type EmbyRemoteLine,
 } from '../utils/embyRemoteLines'
+import { lastPathSegment, syncLocalPathWithRemote } from '../utils/strmPaths'
 
 // ─── 弹框外壳 ────────────────────────────────────────────────────────────────
 
@@ -913,9 +914,26 @@ export function StrmSyncPathDialog({
   const [saving, setSaving] = useState(false)
   const [browsing, setBrowsing] = useState(false)
   const [browsingLocal, setBrowsingLocal] = useState<null | 'remote_path' | 'local_path'>(null)
+  const prevRemoteTailRef = useRef(existing ? lastPathSegment(existing.remote_path) : '')
 
   const set = <K extends keyof StrmSyncPathInput>(key: K, value: StrmSyncPathInput[K]) =>
     setForm((f) => ({ ...f, [key]: value }))
+
+  const updateRemotePath = (remotePath: string) => {
+    setForm((f) => {
+      const synced = syncLocalPathWithRemote(f.local_path, remotePath, prevRemoteTailRef.current)
+      prevRemoteTailRef.current = synced.remoteTail
+      return { ...f, remote_path: remotePath, local_path: synced.localPath }
+    })
+  }
+
+  const commitLocalPath = (localPath: string) => {
+    setForm((f) => {
+      const synced = syncLocalPathWithRemote(localPath, f.remote_path, prevRemoteTailRef.current)
+      prevRemoteTailRef.current = synced.remoteTail
+      return { ...f, local_path: synced.localPath }
+    })
+  }
 
   const isLocal = form.provider === 'local'
   const availableAccounts = accounts.filter((a) => a.provider === form.provider && a.has_credential)
@@ -1000,7 +1018,15 @@ export function StrmSyncPathDialog({
                       : '远端路径（可通过浏览选择）'
                 }
               >
-                <input className={inputCls} value={form.remote_path} placeholder={isLocal ? 'D:\\movies' : '/'} onChange={(e) => set('remote_path', e.target.value)} />
+                <input
+                  className={inputCls}
+                  value={form.remote_path}
+                  placeholder={isLocal ? 'D:\\movies' : '/'}
+                  onChange={(e) => set('remote_path', e.target.value)}
+                  onBlur={(e) => {
+                    if (!isLocal) updateRemotePath(e.target.value)
+                  }}
+                />
               </Field>
             </div>
             {isLocal && (
@@ -1023,8 +1049,23 @@ export function StrmSyncPathDialog({
         <div className="space-y-1">
           <div className="flex items-end gap-2">
             <div className="flex-1">
-              <Field label="本地输出目录" hint="生成的 .strm 与下载的元数据写到这里的对应目录结构下">
-                <input className={inputCls} value={form.local_path} placeholder="D:\\strm\\movies" onChange={(e) => set('local_path', e.target.value)} />
+              <Field
+                label="本地输出目录"
+                hint={
+                  !isLocal && lastPathSegment(form.remote_path)
+                    ? `将自动拼接远端末级目录「${lastPathSegment(form.remote_path)}」`
+                    : '生成的 .strm 与下载的元数据写到这里的对应目录结构下'
+                }
+              >
+                <input
+                  className={inputCls}
+                  value={form.local_path}
+                  placeholder="D:\\strm\\movies"
+                  onChange={(e) => set('local_path', e.target.value)}
+                  onBlur={(e) => {
+                    if (!isLocal) commitLocalPath(e.target.value)
+                  }}
+                />
               </Field>
             </div>
             <button
@@ -1109,7 +1150,7 @@ export function StrmSyncPathDialog({
           accountId={form.account_id}
           initialDir={form.remote_path || undefined}
           onSelect={(id) => {
-            set('remote_path', id)
+            updateRemotePath(id)
             setBrowsing(false)
           }}
           onClose={() => setBrowsing(false)}
@@ -1120,7 +1161,11 @@ export function StrmSyncPathDialog({
         <LocalDirBrowserDialog
           initialDir={form[browsingLocal] || undefined}
           onSelect={(path) => {
-            set(browsingLocal, path)
+            if (browsingLocal === 'local_path') {
+              commitLocalPath(path)
+            } else {
+              set(browsingLocal, path)
+            }
             setBrowsingLocal(null)
           }}
           onClose={() => setBrowsingLocal(null)}

--- a/web/src/utils/strmPaths.ts
+++ b/web/src/utils/strmPaths.ts
@@ -1,0 +1,53 @@
+/** 取路径最后一级目录/文件名（兼容 / 与 \\）。 */
+export function lastPathSegment(path: string): string {
+  const trimmed = path.trim().replace(/[\\/]+$/, '')
+  if (!trimmed) return ''
+  const parts = trimmed.split(/[/\\]/).filter(Boolean)
+  return parts[parts.length - 1] ?? ''
+}
+
+function pathSeparator(path: string): '/' | '\\' {
+  return path.includes('\\') ? '\\' : '/'
+}
+
+function normalizeSlashes(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+/** 去掉 local 末尾与 prevRemoteTail 匹配的自动拼接段。 */
+function stripRemoteTail(localPath: string, prevRemoteTail: string): string {
+  if (!prevRemoteTail) return localPath.trim()
+  const trimmed = localPath.trim()
+  if (!trimmed) return ''
+  const norm = normalizeSlashes(trimmed)
+  const suffix = '/' + prevRemoteTail
+  if (norm.endsWith(suffix)) {
+    const stripped = norm.slice(0, -suffix.length)
+    if (!stripped) return ''
+    return stripped.split('/').join(pathSeparator(trimmed))
+  }
+  if (norm === prevRemoteTail) return ''
+  return trimmed
+}
+
+/** 将远端最后一级目录名拼到本地输出目录末尾；远端变更时替换旧尾段。 */
+export function syncLocalPathWithRemote(
+  localPath: string,
+  remotePath: string,
+  prevRemoteTail = '',
+): { localPath: string; remoteTail: string } {
+  const remoteTail = lastPathSegment(remotePath)
+  const base = stripRemoteTail(localPath, prevRemoteTail)
+  if (!remoteTail) {
+    return { localPath: base || localPath.trim(), remoteTail: '' }
+  }
+  if (!base) {
+    return { localPath: localPath.trim(), remoteTail }
+  }
+  const sep = pathSeparator(base)
+  const normBase = normalizeSlashes(base)
+  if (normBase.endsWith('/' + remoteTail)) {
+    return { localPath: base, remoteTail }
+  }
+  return { localPath: `${base}${sep}${remoteTail}`, remoteTail }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动

添加/编辑 STRM 同步目录时，自动将**远端目录最后一级**拼接到**本地输出目录**末尾。

示例：
- 远端：`/115/影视资源/电影`
- 本地输入：`/home/ubuntu/strm`
- 自动结果：`/home/ubuntu/strm/电影`

## 行为说明

- **浏览选择远端目录**：立即更新本地输出路径
- **手动输入远端路径**：失焦（blur）后更新本地输出路径
- **浏览/输入本地目录**：选择或输入基础路径后，自动拼接当前远端末级目录
- **切换远端目录**：替换之前自动拼接的末级目录（如 `电影` → `电视剧`）
- **本地目录同步类型**：不启用此规则（本地源目录即本地输出）
- 字段提示会显示当前将自动拼接的末级目录名

## 测试

- `npm run build` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7af3b37e-e6ef-43d6-b2a7-2f161461ea2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7af3b37e-e6ef-43d6-b2a7-2f161461ea2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

