### PR TITLE
fix: 挂载 Emby 媒体库置顶失效并误清本地置顶

### DIFF
--- a/internal/service/profile.go
+++ b/internal/service/profile.go
@@ -119,6 +119,9 @@ func (p *ProfileService) SetPinnedLibraryIDs(ctx context.Context, userID string,
 		return nil, err
 	}
 	normalized := filterPinnedLibraryIDs(normalizePinnedLibraryIDs(ids), accessible)
+	if normalized == nil {
+		normalized = []string{}
+	}
 	raw, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, err
@@ -145,6 +148,22 @@ func (p *ProfileService) accessibleLibraryIDSet(ctx context.Context, visibility 
 			continue
 		}
 		out[lib.ID] = struct{}{}
+	}
+	// Mounted Emby libraries are not rows in the local libraries table; their
+	// web IDs are embyremote~{mountID}~{remoteViewID}. Include enabled mounts
+	// from the mount table so pinning them does not get stripped (and so a
+	// pin-save that includes remotes cannot accidentally wipe local pins).
+	if p.repo.EmbyMount != nil {
+		mounts, err := p.repo.EmbyMount.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, mount := range mounts {
+			if !mount.Enabled || strings.TrimSpace(mount.RemoteViewID) == "" {
+				continue
+			}
+			out[EncodeEmbyRemoteID(mount.ID, mount.RemoteViewID)] = struct{}{}
+		}
 	}
 	return out, nil
 }

--- a/internal/service/profile_pinned_test.go
+++ b/internal/service/profile_pinned_test.go
@@ -16,7 +16,7 @@ func TestProfilePinnedLibrariesFiltersInaccessibleAndPreservesOrder(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&model.User{}, &model.Library{}); err != nil {
+	if err := db.AutoMigrate(&model.User{}, &model.Library{}, &model.EmbyMount{}); err != nil {
 		t.Fatal(err)
 	}
 	repos := repository.New(db)
@@ -47,6 +47,68 @@ func TestProfilePinnedLibrariesFiltersInaccessibleAndPreservesOrder(t *testing.T
 		t.Fatalf("SetPinnedLibraryIDs: %v", err)
 	}
 	want := []string{libB.ID, libA.ID}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SetPinnedLibraryIDs = %v, want %v", got, want)
+	}
+
+	loaded, err := svc.GetPinnedLibraryIDs(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf("GetPinnedLibraryIDs: %v", err)
+	}
+	if len(loaded) != len(want) || loaded[0] != want[0] || loaded[1] != want[1] {
+		t.Fatalf("GetPinnedLibraryIDs = %v, want %v", loaded, want)
+	}
+}
+
+func TestProfilePinnedLibrariesKeepsMountedEmbyAndLocalPins(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.User{}, &model.Library{}, &model.EmbyMount{}); err != nil {
+		t.Fatal(err)
+	}
+	repos := repository.New(db)
+	svc := NewProfileService(zap.NewNop(), repos)
+
+	user := &model.User{Username: "viewer", PasswordHash: "hash", Role: "user"}
+	if err := repos.User.Create(t.Context(), user); err != nil {
+		t.Fatal(err)
+	}
+	local := &model.Library{Name: "Movies", Path: "/media/movies", Type: "movie", Enabled: true}
+	if err := repos.Library.Create(t.Context(), local); err != nil {
+		t.Fatal(err)
+	}
+	mount := &model.EmbyMount{
+		AccountID:      "acct-1",
+		RemoteViewID:   "view-42",
+		RemoteViewName: "Remote Movies",
+		Enabled:        true,
+	}
+	if err := repos.EmbyMount.Create(t.Context(), mount); err != nil {
+		t.Fatal(err)
+	}
+	remoteID := EncodeEmbyRemoteID(mount.ID, mount.RemoteViewID)
+	disabled := &model.EmbyMount{
+		AccountID:    "acct-1",
+		RemoteViewID: "view-99",
+		Enabled:      true,
+	}
+	if err := repos.EmbyMount.Create(t.Context(), disabled); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(disabled).Update("enabled", false).Error; err != nil {
+		t.Fatal(err)
+	}
+	disabledID := EncodeEmbyRemoteID(disabled.ID, disabled.RemoteViewID)
+
+	got, err := svc.SetPinnedLibraryIDs(t.Context(), user.ID, []string{
+		local.ID, remoteID, disabledID, "embyremote~missing~view",
+	})
+	if err != nil {
+		t.Fatalf("SetPinnedLibraryIDs: %v", err)
+	}
+	want := []string{local.ID, remoteID}
 	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("SetPinnedLibraryIDs = %v, want %v", got, want)
 	}

--- a/web/src/hooks/usePinnedLibraries.ts
+++ b/web/src/hooks/usePinnedLibraries.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   loadPinnedLibraryIds,
@@ -10,16 +10,26 @@ export function usePinnedLibraries() {
   const [pinnedIds, setPinnedIds] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const loadedRef = useRef(false)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
+    setLoadError(false)
+    loadedRef.current = false
     loadPinnedLibraryIds()
       .then((ids) => {
-        if (!cancelled) setPinnedIds(ids)
+        if (cancelled) return
+        loadedRef.current = true
+        setPinnedIds(ids)
+        setLoadError(false)
       })
       .catch(() => {
-        if (!cancelled) setPinnedIds([])
+        if (cancelled) return
+        loadedRef.current = false
+        setLoadError(true)
+        // Keep any existing pins in memory; never replace a known server list with [].
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -30,6 +40,11 @@ export function usePinnedLibraries() {
   }, [])
 
   const togglePin = useCallback(async (libraryId: string) => {
+    // Avoid saving from an unloaded/failed state — that would overwrite the
+    // server list with only the clicked id and can wipe existing local pins
+    // when mounted Emby ids used to be filtered out server-side.
+    if (!loadedRef.current || loading || loadError) return
+
     let previous: string[] = []
     let optimistic: string[] = []
     setPinnedIds((current) => {
@@ -46,7 +61,7 @@ export function usePinnedLibraries() {
     } finally {
       setSyncing(false)
     }
-  }, [])
+  }, [loading, loadError])
 
-  return { pinnedIds, loading, syncing, togglePin }
+  return { pinnedIds, loading, syncing, loadError, togglePin }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修复「置顶挂载 Emby 媒体库失效，并连带取消本地媒体库置顶」的问题。

## Root cause

置顶落库后，`SetPinnedLibraryIDs` / `GetPinnedLibraryIDs` 用 `accessibleLibraryIDSet` 过滤 ID，但该集合**只查本地 `libraries` 表**。

挂载 Emby 库的 ID 是 `embyremote~{mountID}~{viewID}`，不在本地表里，因此每次保存都会被滤掉。

连锁后果：
1. 前端乐观更新为 `[本地A, 本地B, 远程R]`
2. 后端过滤后返回（或在加载失败时以不完整列表覆盖）更短的列表
3. 前端用返回值覆盖状态 → 远程置顶失效；在加载失败/空状态下再保存时，甚至可能把服务端已有的本地置顶写成空

## Fix

1. **后端**：`accessibleLibraryIDSet` 同时纳入 `emby_mounts` 中已启用的挂载（用稳定伪装 ID，不依赖远程 Emby 在线）
2. **前端**：置顶列表未成功加载前禁止 toggle，避免用残缺本地状态整表覆盖服务端

## Test plan

- [x] `go test ./internal/service/... -run TestProfilePinned`
- [ ] 置顶本地库 + 挂载 Emby 库，刷新后两者都保持
- [ ] 仅置顶挂载 Emby 库，刷新后仍置顶
- [ ] 已置顶本地库不会因再置顶挂载库而被取消
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2455272d-a2ed-4009-a017-401c5c49b5cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2455272d-a2ed-4009-a017-401c5c49b5cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

