### PR TITLE
fix: 置顶挂载 Emby 库时误清空全部置顶（React 竞态）

### DIFF
--- a/web/src/hooks/usePinnedLibraries.ts
+++ b/web/src/hooks/usePinnedLibraries.ts
@@ -12,6 +12,12 @@ export function usePinnedLibraries() {
   const [syncing, setSyncing] = useState(false)
   const [loadError, setLoadError] = useState(false)
   const loadedRef = useRef(false)
+  const pinnedIdsRef = useRef<string[]>([])
+  const syncingRef = useRef(false)
+
+  useEffect(() => {
+    pinnedIdsRef.current = pinnedIds
+  }, [pinnedIds])
 
   useEffect(() => {
     let cancelled = false
@@ -22,6 +28,7 @@ export function usePinnedLibraries() {
       .then((ids) => {
         if (cancelled) return
         loadedRef.current = true
+        pinnedIdsRef.current = ids
         setPinnedIds(ids)
         setLoadError(false)
       })
@@ -29,7 +36,6 @@ export function usePinnedLibraries() {
         if (cancelled) return
         loadedRef.current = false
         setLoadError(true)
-        // Keep any existing pins in memory; never replace a known server list with [].
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -40,25 +46,27 @@ export function usePinnedLibraries() {
   }, [])
 
   const togglePin = useCallback(async (libraryId: string) => {
-    // Avoid saving from an unloaded/failed state — that would overwrite the
-    // server list with only the clicked id and can wipe existing local pins
-    // when mounted Emby ids used to be filtered out server-side.
-    if (!loadedRef.current || loading || loadError) return
+    if (!loadedRef.current || loading || loadError || syncingRef.current) return
 
-    let previous: string[] = []
-    let optimistic: string[] = []
-    setPinnedIds((current) => {
-      previous = current
-      optimistic = togglePinnedLibraryId(current, libraryId)
-      return optimistic
-    })
+    // Compute the next list synchronously from a ref. Do NOT capture the next
+    // value inside setState updater callbacks — React may defer those, leaving
+    // optimistic as [] and wiping the server-side pin list.
+    const previous = pinnedIdsRef.current
+    const optimistic = togglePinnedLibraryId(previous, libraryId)
+
+    pinnedIdsRef.current = optimistic
+    setPinnedIds(optimistic)
+    syncingRef.current = true
     setSyncing(true)
     try {
       const saved = await savePinnedLibraryIds(optimistic)
+      pinnedIdsRef.current = saved
       setPinnedIds(saved)
     } catch {
+      pinnedIdsRef.current = previous
       setPinnedIds(previous)
     } finally {
+      syncingRef.current = false
       setSyncing(false)
     }
   }, [loading, loadError])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

复现「先置顶本地库成功，再置顶挂载 Emby 库 → 页面闪一下，两边置顶都没了」的根因是前端竞态，不是后端再次过滤失败。

## Root cause

`usePinnedLibraries` 在 `setPinnedIds` 的 updater 里给 `optimistic` 赋值，然后立刻 `savePinnedLibraryIds(optimistic)`：

```ts
let optimistic: string[] = []
setPinnedIds((current) => {
  optimistic = togglePinnedLibraryId(current, libraryId)
  return optimistic
})
await savePinnedLibraryIds(optimistic) // React 可能还没跑 updater，这里仍是 []
```

React 18 下 updater 不一定同步执行，结果常常是：

1. 先把 `[]` 写进服务端（清空已有本地置顶）
2. updater 随后跑完，UI 短暂显示「本地+远程都置顶」→ 闪烁
3. 请求返回 `[]`，再 `setPinnedIds([])` → 全部取消

这与你描述的现象完全一致。

## Fix

在调用 `setState` 之前，用 `pinnedIdsRef` **同步**算出 `previous` / `optimistic`，再保存；并用 `syncingRef` 防止连点重复提交。

## Test plan

- [ ] 置顶一个本地媒体库，确认成功
- [ ] 再置顶一个挂载 Emby 媒体库
- [ ] 两者都应保持置顶，页面不应再闪一下后全清
- [ ] 刷新后置顶状态仍在
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2455272d-a2ed-4009-a017-401c5c49b5cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2455272d-a2ed-4009-a017-401c5c49b5cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

