### PR TITLE
feat: Emby 客户端媒体库列表遵循网页置顶顺序

### DIFF
--- a/internal/service/emby_system.go
+++ b/internal/service/emby_system.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 
@@ -125,7 +126,8 @@ func (e *EmbyService) userPayload(u *model.User) map[string]any {
 }
 
 // Views 返回 Emby 中"虚拟根目录"——每个 library 一个条目，外加所有启用的
-// 远程 Emby 挂载的媒体库（联邦聚合）。
+// 远程 Emby 挂载的媒体库（联邦聚合）。顺序遵循用户置顶偏好：置顶库靠前，
+// 未置顶保持原有 sort_order / 远程挂载顺序。
 func (e *EmbyService) Views(ctx context.Context, userID string) (map[string]any, error) {
 	libs, err := e.repo.Library.List(ctx)
 	if err != nil {
@@ -143,7 +145,52 @@ func (e *EmbyService) Views(ctx context.Context, userID string) (map[string]any,
 	for _, remote := range e.remoteViews(ctx) {
 		items = append(items, remote)
 	}
+	items = sortViewItemsByPinnedIDs(items, e.pinnedLibraryIDsForUser(ctx, userID))
 	return map[string]any{"Items": items, "TotalRecordCount": len(items), "StartIndex": 0}, nil
+}
+
+func (e *EmbyService) pinnedLibraryIDsForUser(ctx context.Context, userID string) []string {
+	if e == nil || e.repo == nil || e.repo.User == nil || strings.TrimSpace(userID) == "" {
+		return nil
+	}
+	user, err := e.repo.User.FindByID(ctx, userID)
+	if err != nil || user == nil {
+		return nil
+	}
+	return user.DecodePinnedLibraryIDs()
+}
+
+func sortViewItemsByPinnedIDs(items []map[string]any, pinnedIDs []string) []map[string]any {
+	if len(items) < 2 || len(pinnedIDs) == 0 {
+		return items
+	}
+	rank := make(map[string]int, len(pinnedIDs))
+	for i, id := range pinnedIDs {
+		if id == "" {
+			continue
+		}
+		if _, exists := rank[id]; !exists {
+			rank[id] = i
+		}
+	}
+	if len(rank) == 0 {
+		return items
+	}
+	sorted := append([]map[string]any(nil), items...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		iID, _ := sorted[i]["Id"].(string)
+		jID, _ := sorted[j]["Id"].(string)
+		iRank, iPinned := rank[iID]
+		jRank, jPinned := rank[jID]
+		if iPinned != jPinned {
+			return iPinned
+		}
+		if iPinned && jPinned {
+			return iRank < jRank
+		}
+		return false
+	})
+	return sorted
 }
 
 // remoteViews 返回全部启用挂载的远程媒体库视图（只有显式挂载的库才出现）。

--- a/internal/service/emby_views_pinned_test.go
+++ b/internal/service/emby_views_pinned_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/truewhile/MeBox/internal/model"
+)
+
+func TestViewsOrdersPinnedLibrariesFirst(t *testing.T) {
+	svc := newTestEmbyService(t)
+	first := model.Library{Name: "AAA", Path: "/media/a", Type: "movie", Enabled: true, SortOrder: 0}
+	second := model.Library{Name: "BBB", Path: "/media/b", Type: "movie", Enabled: true, SortOrder: 1}
+	third := model.Library{Name: "CCC", Path: "/media/c", Type: "movie", Enabled: true, SortOrder: 2}
+	for _, lib := range []*model.Library{&first, &second, &third} {
+		if err := svc.repo.Library.Create(t.Context(), lib); err != nil {
+			t.Fatalf("create library: %v", err)
+		}
+	}
+
+	user := &model.User{Username: "viewer", PasswordHash: "hash", Role: "user"}
+	pinned, err := json.Marshal([]string{third.ID, first.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user.PinnedLibraryIDs = string(pinned)
+	if err := svc.repo.User.Create(t.Context(), user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	views, err := svc.Views(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf("Views: %v", err)
+	}
+	items := views["Items"].([]map[string]any)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 views, got %d", len(items))
+	}
+	got := []string{items[0]["Id"].(string), items[1]["Id"].(string), items[2]["Id"].(string)}
+	want := []string{third.ID, first.ID, second.ID}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Views order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSortViewItemsByPinnedIDsKeepsUnpinnedOrder(t *testing.T) {
+	items := []map[string]any{
+		{"Id": "a", "Name": "A"},
+		{"Id": "b", "Name": "B"},
+		{"Id": "c", "Name": "C"},
+		{"Id": "d", "Name": "D"},
+	}
+	sorted := sortViewItemsByPinnedIDs(items, []string{"c", "a"})
+	got := make([]string, len(sorted))
+	for i, item := range sorted {
+		got[i] = item["Id"].(string)
+	}
+	want := []string{"c", "a", "b", "d"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

网页置顶媒体库后，第三方 Emby 客户端（Infuse / Emby / Jellyfin 等）的媒体库列表也会把置顶库排到前面。

## Changes

- `EmbyService.Views` 读取当前用户的 `pinned_library_ids`
- 置顶库按置顶顺序靠前；未置顶库保持原有 `sort_order` / 远程挂载顺序（稳定排序）
- 本地库与挂载 Emby 库（`embyremote~...`）都支持

## Test plan

- [x] `go test ./internal/service/... -run 'TestViewsOrdersPinned|TestSortViewItemsByPinned'`
- [ ] 网页置顶本地库 + 挂载 Emby 库
- [ ] Emby 客户端刷新媒体库列表，置顶项应在最前
- [ ] 取消置顶后客户端顺序恢复
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2455272d-a2ed-4009-a017-401c5c49b5cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2455272d-a2ed-4009-a017-401c5c49b5cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

