### PR TITLE
fix: 用户媒体库权限可管控挂载 Emby 库

### DIFF
--- a/internal/handler/media.go
+++ b/internal/handler/media.go
@@ -94,18 +94,26 @@ func listLibrariesHandler(svc *service.Container) gin.HandlerFunc {
 				out = append(out, webLibraryPayload{Library: l})
 			}
 		}
-		// 远程 Emby 挂载库追加在本地库之后。
+		// 远程 Emby 挂载库追加在本地库之后（非管理员视图仍受 allowed_library_ids 约束）。
 		if svc.EmbyRemote != nil {
 			if views, err := svc.EmbyRemote.RemoteLibraries(ctx); err == nil {
-				remotePayloads := make([]webLibraryPayload, len(views))
-				for i, v := range views {
+				visibility := mediaVisibilityForRequest(c, svc)
+				allowedViews := make([]service.RemoteLibraryView, 0, len(views))
+				for _, v := range views {
+					if !includeHidden && !service.LibraryVisibleForUser(ctx, svc.Repo, v.Library, visibility) {
+						continue
+					}
+					allowedViews = append(allowedViews, v)
+				}
+				remotePayloads := make([]webLibraryPayload, len(allowedViews))
+				for i, v := range allowedViews {
 					remotePayloads[i] = webLibraryPayload{Library: v.Library, IsRemoteEmby: true, RemoteSource: v.AccountName}
 				}
-				if withPreview && len(views) > 0 {
+				if withPreview && len(allowedViews) > 0 {
 					const maxRemotePreviewWorkers = 6
 					sem := make(chan struct{}, maxRemotePreviewWorkers)
 					var wg sync.WaitGroup
-					for i, v := range views {
+					for i, v := range allowedViews {
 						i, v := i, v
 						wg.Add(1)
 						go func() {
@@ -148,6 +156,12 @@ func getLibraryHandler(svc *service.Container) gin.HandlerFunc {
 			mountID, remoteID, _ := service.DecodeEmbyRemoteID(id)
 			view, err := svc.EmbyRemote.RemoteLibraryByID(ctx, mountID, remoteID)
 			if err != nil || view == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			role, _ := c.Get(middleware.CtxUserRole)
+			includeHidden := role == "admin" && (c.Query("include_hidden") == "1" || c.Query("include_hidden") == "true" || c.Query("all") == "1")
+			if !includeHidden && !service.LibraryVisibleForUser(ctx, svc.Repo, view.Library, mediaVisibilityForRequest(c, svc)) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}
@@ -330,6 +344,10 @@ func listMediaHandler(svc *service.Container) gin.HandlerFunc {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
 			itemTypes := ""
 			if view, err := svc.EmbyRemote.RemoteLibraryByID(ctx, mountID, remoteID); err == nil && view != nil {
 				itemTypes = remoteLibraryItemTypes(view.CollectionType)
@@ -394,6 +412,10 @@ func getMediaHandler(svc *service.Container) gin.HandlerFunc {
 			mountID, remoteID, _ := service.DecodeEmbyRemoteID(id)
 			mount, acct, _ := svc.EmbyRemote.ResolveMount(ctx, mountID)
 			if mount == nil || acct == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}
@@ -576,6 +598,10 @@ func streamHandler(svc *service.Container) gin.HandlerFunc {
 			mountID, remoteID, _ := service.DecodeEmbyRemoteID(id)
 			mount, acct, _ := svc.EmbyRemote.ResolveMount(ctx, mountID)
 			if mount == nil || acct == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}

--- a/internal/handler/series.go
+++ b/internal/handler/series.go
@@ -74,6 +74,10 @@ func listLibrarySeriesHandler(svc *service.Container) gin.HandlerFunc {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
 			cards, err := svc.EmbyRemote.RemoteSeriesCards(ctx, mount, acct, remoteID)
 			if err != nil {
 				writeInternalOrCanceled(c, err)
@@ -165,6 +169,10 @@ func listLibrarySeriesEpisodesHandler(svc *service.Container) gin.HandlerFunc {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
 			items, err := svc.EmbyRemote.RemoteEpisodes(ctx, mount, acct, remoteSeriesID)
 			if err != nil {
 				writeInternalOrCanceled(c, err)
@@ -204,6 +212,10 @@ func listMediaEpisodesHandler(svc *service.Container) gin.HandlerFunc {
 			mountID, remoteID, _ := service.DecodeEmbyRemoteID(id)
 			mount, acct, _ := svc.EmbyRemote.ResolveMount(ctx, mountID)
 			if mount == nil || acct == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			if !service.EmbyMountLibraryAllowed(mediaVisibilityForRequest(c, svc), mount) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 				return
 			}

--- a/internal/service/emby_compat.go
+++ b/internal/service/emby_compat.go
@@ -156,6 +156,9 @@ func (e *EmbyService) Items(ctx context.Context, p ItemsParams) (map[string]any,
 			if mount == nil || acct == nil {
 				return emptyItemsEnvelope(p.StartIndex), nil
 			}
+			if !EmbyMountLibraryAllowed(e.mediaVisibility(ctx, p.UserID), mount) {
+				return emptyItemsEnvelope(p.StartIndex), nil
+			}
 			out, err := e.remote.RemoteItems(ctx, mount, acct, p)
 			if err != nil {
 				return nil, err
@@ -273,6 +276,9 @@ func (e *EmbyService) aggregatedSearch(ctx context.Context, p ItemsParams) (map[
 		for i := range mounts {
 			m := mounts[i]
 			if !m.Enabled {
+				continue
+			}
+			if !EmbyMountLibraryAllowed(e.mediaVisibility(ctx, p.UserID), &m) {
 				continue
 			}
 			acct := e.remote.AccountByID(ctx, m.AccountID)

--- a/internal/service/emby_items_detail.go
+++ b/internal/service/emby_items_detail.go
@@ -21,6 +21,9 @@ func (e *EmbyService) Item(ctx context.Context, mediaID, userID string) (map[str
 		if mount == nil || acct == nil {
 			return nil, nil
 		}
+		if !EmbyMountLibraryAllowed(e.mediaVisibility(ctx, userID), mount) {
+			return nil, nil
+		}
 		out, err := e.remote.RemoteItem(ctx, mount, acct, remoteID)
 		if err != nil || out == nil {
 			return out, err
@@ -107,6 +110,9 @@ func (e *EmbyService) LatestItems(ctx context.Context, userID, parentID string, 
 		mountID, remoteParent, _ := DecodeEmbyRemoteID(parentID)
 		mount, acct, _ := e.remote.ResolveMount(ctx, mountID)
 		if mount == nil || acct == nil {
+			return nil, nil
+		}
+		if !EmbyMountLibraryAllowed(e.mediaVisibility(ctx, userID), mount) {
 			return nil, nil
 		}
 		out, err := e.remote.RemoteLatest(ctx, mount, acct, remoteParent, limit)

--- a/internal/service/emby_mount_acl_test.go
+++ b/internal/service/emby_mount_acl_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/truewhile/MeBox/internal/model"
+)
+
+func TestViewsHidesDisallowedMountedEmbyLibraries(t *testing.T) {
+	svc := newTestEmbyService(t)
+	if err := svc.repo.DB.AutoMigrate(&model.EmbyMount{}); err != nil {
+		t.Fatal(err)
+	}
+	local := model.Library{Name: "Local", Path: "/media/local", Type: "movie", Enabled: true}
+	if err := svc.repo.Library.Create(t.Context(), &local); err != nil {
+		t.Fatal(err)
+	}
+	mount := &model.EmbyMount{
+		AccountID:      "acct-1",
+		RemoteViewID:   "view-1",
+		RemoteViewName: "Remote Movies",
+		Enabled:        true,
+	}
+	if err := svc.repo.EmbyMount.Create(t.Context(), mount); err != nil {
+		t.Fatal(err)
+	}
+	remoteID := EncodeEmbyRemoteID(mount.ID, mount.RemoteViewID)
+
+	user := &model.User{Username: "viewer", PasswordHash: "hash", Role: "user"}
+	allowed, err := json.Marshal([]string{local.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user.AllowedLibraryIDs = string(allowed)
+	if err := svc.repo.User.Create(t.Context(), user); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without a live remote service, remoteViews is empty; assert helper ACL instead
+	// and that local Views still honor the allow-list.
+	views, err := svc.Views(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf("Views: %v", err)
+	}
+	items := views["Items"].([]map[string]any)
+	for _, item := range items {
+		if id, _ := item["Id"].(string); id == remoteID {
+			t.Fatalf("disallowed remote library should not appear in Views: %#v", item)
+		}
+	}
+	if !EmbyMountLibraryAllowed(MediaVisibility{AllowedLibraryIDs: []string{local.ID, remoteID}}, mount) {
+		t.Fatal("expected remote library allowed when listed")
+	}
+	if EmbyMountLibraryAllowed(MediaVisibility{AllowedLibraryIDs: []string{local.ID}}, mount) {
+		t.Fatal("expected remote library denied when not listed")
+	}
+}
+
+func TestLibraryIDAllowed(t *testing.T) {
+	if !LibraryIDAllowed(MediaVisibility{}, "any") {
+		t.Fatal("empty allow-list should allow all")
+	}
+	if LibraryIDAllowed(MediaVisibility{AllowedLibraryIDs: []string{"a"}}, "b") {
+		t.Fatal("missing id should be denied")
+	}
+	if !LibraryIDAllowed(MediaVisibility{AllowedLibraryIDs: []string{"a", "b"}}, "b") {
+		t.Fatal("listed id should be allowed")
+	}
+}

--- a/internal/service/emby_playback.go
+++ b/internal/service/emby_playback.go
@@ -24,6 +24,9 @@ func (e *EmbyService) PlaybackInfo(ctx context.Context, mediaID, userID string) 
 		if err != nil {
 			return nil, ErrEmbyRemoteNotFound
 		}
+		if !EmbyMountLibraryAllowed(e.mediaVisibility(ctx, userID), mount) {
+			return nil, ErrEmbyRemoteNotFound
+		}
 		out, err := e.remote.RemotePlaybackInfo(ctx, mount, acct, remoteID, userID)
 		if err != nil {
 			return nil, err

--- a/internal/service/emby_system.go
+++ b/internal/service/emby_system.go
@@ -143,6 +143,10 @@ func (e *EmbyService) Views(ctx context.Context, userID string) (map[string]any,
 		items = append(items, e.libraryAsView(ctx, &l))
 	}
 	for _, remote := range e.remoteViews(ctx) {
+		id, _ := remote["Id"].(string)
+		if !LibraryIDAllowed(visibility, id) {
+			continue
+		}
 		items = append(items, remote)
 	}
 	items = sortViewItemsByPinnedIDs(items, e.pinnedLibraryIDsForUser(ctx, userID))

--- a/internal/service/visibility.go
+++ b/internal/service/visibility.go
@@ -131,20 +131,39 @@ func DecodeAllowedLibraryIDs(raw string) []string {
 	return out
 }
 
+// LibraryIDAllowed reports whether libraryID is permitted by the allow-list.
+// An empty AllowedLibraryIDs means unrestricted access.
+func LibraryIDAllowed(visibility MediaVisibility, libraryID string) bool {
+	if len(visibility.AllowedLibraryIDs) == 0 {
+		return true
+	}
+	for _, id := range visibility.AllowedLibraryIDs {
+		if id == libraryID {
+			return true
+		}
+	}
+	return false
+}
+
+// EmbyMountLibraryID is the web/Emby library id for a mounted remote view.
+func EmbyMountLibraryID(mount *model.EmbyMount) string {
+	if mount == nil {
+		return ""
+	}
+	return EncodeEmbyRemoteID(mount.ID, mount.RemoteViewID)
+}
+
+// EmbyMountLibraryAllowed reports whether a mounted Emby library is allowed for
+// the given visibility policy.
+func EmbyMountLibraryAllowed(visibility MediaVisibility, mount *model.EmbyMount) bool {
+	return LibraryIDAllowed(visibility, EmbyMountLibraryID(mount))
+}
+
 // LibraryVisibleForUser applies profile library limits and adult-directory
 // hiding to a library card/folder.
 func LibraryVisibleForUser(ctx context.Context, repo *repository.Container, lib model.Library, visibility MediaVisibility) bool {
-	if len(visibility.AllowedLibraryIDs) > 0 {
-		found := false
-		for _, id := range visibility.AllowedLibraryIDs {
-			if id == lib.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
+	if !LibraryIDAllowed(visibility, lib.ID) {
+		return false
 	}
 	if visibility.IncludeNSFW {
 		return true

--- a/web/src/components/AdminUserLibrariesDialog.tsx
+++ b/web/src/components/AdminUserLibrariesDialog.tsx
@@ -278,12 +278,19 @@ export function AdminUserLibrariesDialog({
                           <div className="min-w-0 flex-1">
                             <p className="truncate text-xs font-semibold text-ink-600">
                               {lib.name}
+                              {lib.is_remote_emby ? (
+                                <span className="ml-1.5 rounded bg-sky-50 px-1.5 py-0.5 text-[10px] font-bold text-sky-700">
+                                  Emby 挂载
+                                </span>
+                              ) : null}
                             </p>
                             <p
                               className="truncate text-[10px] text-sand-500"
-                              title={lib.path}
+                              title={lib.is_remote_emby ? lib.remote_source || lib.name : lib.path}
                             >
-                              {lib.type} · {libraryDisplayPath(lib.path)}
+                              {lib.is_remote_emby
+                                ? `远程 · ${lib.remote_source || 'Emby'}`
+                                : `${lib.type} · ${libraryDisplayPath(lib.path)}`}
                             </p>
                           </div>
                         </div>

--- a/web/src/pages/ProfileFormSections.tsx
+++ b/web/src/pages/ProfileFormSections.tsx
@@ -155,6 +155,7 @@ export function ProfileLibraryAccessField({
             }
           >
             {library.name}
+            {library.is_remote_emby ? ' · Emby' : ''}
           </button>
         ))}
         {libraries.length === 0 && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

挂载的 Emby 媒体库此前不受用户「指定可访问媒体库」限制，所有人都能看到/打开。现已与本地库走同一套 `allowed_library_ids` 管控。

## Root cause

本地库会按 `AllowedLibraryIDs` 过滤，但远程挂载库在以下路径被无条件追加/放行：
- 网页 `/api/libraries` 列表与详情
- 库内媒体 / 剧集 / 播放
- Emby 客户端 `Views` / `Items` / 搜索 / PlaybackInfo

## Changes

1. **统一 ACL 辅助**：`LibraryIDAllowed` / `EmbyMountLibraryAllowed`
2. **网页 API**：列表、详情、媒体、剧集、流媒体均校验挂载库权限
3. **Emby 协议**：Views / Items / Latest / 搜索 / 播放同样校验
4. **管理 UI**：用户媒体库权限弹窗与播放配置里，挂载库显示「Emby 挂载」标记，便于勾选管控

## 行为说明

- 「全部媒体库」：仍可访问全部本地 + 挂载库
- 「指定可访问媒体库」：未勾选的挂载 Emby 库对用户不可见、不可播
- 管理员配置权限时列表会包含挂载库

## Test plan

- [x] `go test ./internal/service/... -run 'LibraryIDAllowed|ViewsHidesDisallowed'`
- [x] frontend `tsc -b`
- [ ] 给普通用户指定仅本地库 → 网页/Emby 客户端不应再看到挂载库
- [ ] 勾选某个挂载库 → 仅该挂载库可见
- [ ] 管理员用户管理弹窗能看到并勾选挂载库
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2455272d-a2ed-4009-a017-401c5c49b5cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2455272d-a2ed-4009-a017-401c5c49b5cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

